### PR TITLE
chore(ci): add github action workflow to repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: "CI"
+on: push
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+    container: node:10.13-stretch
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Install NPM dependencies"
+        run: npm ci
+      - name: "Run Jest"
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# github-frontend-coverage-action
+# github-frontend-coverage-action ![example workflow](https://github.com/jobteaser/github-frontend-coverage-action/actions/workflows/ci.yml/badge.svg)
 
 This Github action allows to compute test coverage (as reported by Jest) and to monitor it by sending coverage metrics to Pushgateway of Prometheus. What you do with those metrics is up to you but you may choose to display them in a Grafana dashboard for example.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# github-frontend-coverage-action ![example workflow](https://github.com/jobteaser/github-frontend-coverage-action/actions/workflows/ci.yml/badge.svg)
+# github-frontend-coverage-action ![ci workflow](https://github.com/jobteaser/github-frontend-coverage-action/actions/workflows/ci.yml/badge.svg)
 
 This Github action allows to compute test coverage (as reported by Jest) and to monitor it by sending coverage metrics to Pushgateway of Prometheus. What you do with those metrics is up to you but you may choose to display them in a Grafana dashboard for example.
 

--- a/src/monitor/metrics-list.spec.js
+++ b/src/monitor/metrics-list.spec.js
@@ -3,8 +3,16 @@ const { getMetricsList } = require("./metrics-list")
 // As returned by jest JSON output
 const testStats = {
     numTotalTestSuites: 1,
-    numTotalTests: 2,
-    snapshot: { total: 3 },
+    numPassedTestSuites: 2,
+    numFailedTestSuites: 3,
+    numPendingTestSuites: 4,
+    numTotalTests: 5,
+    numPassedTests: 6,
+    numPendingTests: 7,
+    numFailedTests: 8,
+    endTime: Date.now(),
+    startTime: Date.now() - 5000,
+    snapshot: { total: 9 },
 }
 // As returned by `json-summary` coverage reporter
 const coverageStats = {


### PR DESCRIPTION
This PR adds a github action workflow to run tests every time someone push to the repo. I also fixed tests that were broken due to new metrics added but not mocked in tests.

I also added a badge in the README to show test status.