### PR TITLE
feat(compute): update action to use a JSON config for folders list

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,8 @@ inputs:
     description: 'Which step to run (compute, monitor)'
     required: true
     default: 'compute'
-  folder-list:
-    description: 'List of targetted folders'
+  folders-config:
+    description: 'JSON config describing the targetted folders'
     required: true
     default: ''
   metric-job-name:
@@ -22,7 +22,7 @@ runs:
   steps:
     - run: |
         if [[ "${{ inputs.task }}" == "compute" ]]; then
-          $GITHUB_ACTION_PATH/src/compute/coverage-all-folders.sh "${{ inputs.folder-list }}"
+          $GITHUB_ACTION_PATH/src/compute/coverage-all-folders.js ${{ inputs.folders-config }}
         else
           exit 0
         fi

--- a/src/compute/coverage-all-folders.js
+++ b/src/compute/coverage-all-folders.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+// This script computes the test coverage for all folders
+
+const path = require("path")
+const { execSync } = require("child_process")
+
+const onError = message => (console.log(message), process.exit(1))
+const run = (task, errorMsg) => {
+    try {
+        task()
+    } catch (e) {
+        onError(`ERROR: ${errorMsg} \n ${e.message}`)
+    }
+}
+
+const foldersConfigPath = process.argv.slice(2)[0]
+
+if (!foldersConfigPath) {
+    onError(
+        `Please provide a JSON config file describing the list of folders against which to run the coverage computation.
+        Ex: $0 folders-config.json`
+    )
+}
+
+// Create artifacts folder
+run(
+    () => execSync("mkdir -p coverage-artifacts"),
+    `Failed to create coverage artifacts folder`
+)
+
+// Compute coverage for all folders
+require(path.resolve(foldersConfigPath))
+    .forEach(({id, folders}) => {
+        run(
+            () => execSync(`${__dirname}/coverage-for-folder.sh -i ${id} -f "${folders.join(" ")}"`),
+            `There was an error when computing coverage for "${id}"`
+        )
+    })
+
+// Tar all coverage stats
+run(
+    () => execSync("tar cvzf coverage-artifacts.tar.gz coverage-artifacts"),
+    `Failed to create coverage-artifacts archive`
+)


### PR DESCRIPTION
This PR updates the github action to allow the computing of coverage to be done for more that one folder.

**Previously**, the github action could only take a list of folders and compute coverage for each one. But if we wanted to compute coverage for 2 or more folders and get metrics as if it was just one folder, it was not possible.

**Now**, we can pass a JSON config describing the list of folders and use it to group folders together.

## Functional review

There isn't anything to test functionally here (it will be tested via another PR on a repo using this github action).