### PR TITLE
fix(compute): incorrect coverage computing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Github action allows to compute test coverage (as reported by Jest) and to 
 ## Prerequisites
 
 For this github action to work, **you must provide**:
-- a **dedicated NPM script called `test:ci:coverage`**. This script when called (by the `compute` step - see below) must run jest with the right jest config. This script must also accept a dynamic path to restrict the run of tests and coverage to a specific folder (ex: `npm run test:ci:coverage -- ./src/feature1`). The script will also be passed other options (`--json`, `--outputFile=jest-output.json`) to retrieve jest test stats. **You are expected to transfer any options passed to `test:ci:coverage`, to Jest CLI**.
+- a **dedicated NPM script called `test:ci:coverage`**. This script when called (by the `compute` step - see below) must run jest with the right jest config. This script must also accept dynamic paths to restrict the run of tests and coverage to a specific list of folders (ex: `npm run test:ci:coverage -- "./src/feature1/foo ./src/feature1/bar"`). The script will also be passed other options (`--json`, `--outputFile=jest-output.json`) to retrieve jest test stats. **You are expected to transfer any options passed to `test:ci:coverage`, to Jest CLI**. It is MANDATORY that the targetted **list of folders is passed as the FIRST argument of `test:ci:coverage` script**.
 - the **coverage reporter `json-summary`** to the list of `coverageReporters` in your jest config (ex: `coverageReporters: ["text", "html", "json-summary"],`)
 - a `coverageDirectory` option to jest config, with the value `<rootDir>/coverage`
 
@@ -76,7 +76,7 @@ The `compute` step expects only one parameter:
 This step will iterate over the provided folder list and call the coverage script **once per folder group**. This will be done thanks to the NPM script `test:ci:coverage` that you must provide (see [prerequisites](#prerequisites)).
 
 ```shell
-npm run test:ci:coverage -- ./src/feature1/foo ./src/feature1/bar
+npm run test:ci:coverage -- "./src/feature1/foo ./src/feature1/bar"
 ```
 
 This step produces an archive called `coverage-artifacts.tar.gz` containing all the computed metrics for all folders (in JSON files).

--- a/src/compute/coverage-for-folder.sh
+++ b/src/compute/coverage-for-folder.sh
@@ -43,8 +43,8 @@ function computeCoverage {
 
     echo "Computing coverage for folders: ${folders}"
 
-    if [[ "$folderPath" =~ $allowList ]]; then
-        npm run test:ci:coverage -- --json --outputFile=jest-output.json ${folders}
+    if [[ "$folders" =~ $allowList ]]; then
+        npm run test:ci:coverage -- "${folders}" --json --outputFile=jest-output.json
 
         # Add endTime of tests to monitor duration
         testEndTime=$(node -e 'console.log(Date.now())')


### PR DESCRIPTION
This PR fixes an incorrect coverage computing due to wrong placement of the argument "list of folders" when calling `npm run test:ci:coverage`.

The list of folders must be passed as the very first argument of `npm run test:ci:coverage`. Also, if multiple folders are passed, they must be wrapped between quotes to allow `npm run test:ci:coverage` to see them as 1 argument.

This behaviour has been made more clear in the README.