### PR TITLE
feat(add-working-directory): add new param 'working-directory'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: 'Frontend coverage'
 description: 'Compute and publish jest coverage for list of folders'
 inputs:
+  working-directory:
+    description: 'The path to the code that was checkout-ed, relative to $GITHUB_WORKSPACE'
+    required: false
+    default: '.'
   task:
     description: 'Which step to run (compute, monitor)'
     required: true
@@ -22,6 +26,7 @@ runs:
   steps:
     - run: |
         if [[ "${{ inputs.task }}" == "compute" ]]; then
+          cd ${{ inputs.working-directory }}
           $GITHUB_ACTION_PATH/src/compute/coverage-all-folders.js ${{ inputs.folders-config }}
         else
           exit 0


### PR DESCRIPTION
## Description

With the update to `node@16` and `npm@7`, we faced an issue when installing dependencies (`npm ci`) in the github action, that forced us to use another folder than the default one to checkout our code. This means that the action `github-frontend-coverage-action` also needs to be aware of the folder where the code has been checkout-ed. It's now possible thanks to the new param `working-directory`.

## Functional review

The GHA with the new param has been tested [here](https://github.com/jobteaser/ui-jobteaser/runs/4023287614?check_suite_focus=true).