### PR TITLE
chore(node-update): use custom directory instead of user 1001

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,14 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: jobteaser/node:2.0.0
-      options: --user 1001
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
+        with:
+          path: workspace
       - name: "Install NPM dependencies"
+        working-directory: workspace
         run: npm ci
       - name: "Run Jest"
+        working-directory: workspace
         run: npm test


### PR DESCRIPTION
## Description

In a [previous PR](https://github.com/jobteaser/github-frontend-coverage-action/pull/5) I made changes to use `node@16` and `npm@7` in the CI of the present repo. However, at that time I faced a permission issue that I chose to fix by forcing use of `user 1001` in the docker container.

I found an other way that I found better, by specifying another folder destination to the checkout action.

We then have to specify `working-directory: workspace` for the `run` steps to make sure that the steps are executed in the folder where the code has been checkout-ed.

## Functional review

You can see [here](https://github.com/jobteaser/github-frontend-coverage-action/actions/runs/1390758096) the workflow using this new config.