### PR TITLE
fix(error-handling): add http error handling

### DIFF
--- a/src/compute/coverage-for-folder.sh
+++ b/src/compute/coverage-for-folder.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # This script computes the test coverage for a list of folders
 
 echo

--- a/src/monitor/push-metrics-all-folders.sh
+++ b/src/monitor/push-metrics-all-folders.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # This script push computed metrics to Prometheus.
 
 # It expects coverage metrics to be exposed in a tar.gz file called

--- a/src/monitor/push-metrics-for-folder.js
+++ b/src/monitor/push-metrics-for-folder.js
@@ -37,18 +37,13 @@ const pushMetricsForFolder = ({ coverageArtifactsPath, folderName, jobName, push
         .reduce((metricsAsText, metric) => metricsAsText + formatMetricPayload(metric), "")
 
     // Sent metrics to Prometheus
-    try {
-        pushToGateway(`${pushGatewayUri}/metrics/job/${jobName}/folder_name/${folderName}`, metricsPayload, (err, data) => {
-            if (err) {
-                throw new Error(err.message)
-            }
+    pushToGateway(`${pushGatewayUri}/metrics/job/${jobName}/folder_name/${folderName}`, metricsPayload, (err, data) => {
+        if (err) {
+            throw new Error(err.message)
+        }
 
-            console.log("Done -", data.body)
-        })
-    }
-    catch(e) {
-        throw new Error(`ERROR: ${e.message}`)
-    }
+        console.log("Done -", data.body)
+    })
 }
 
 // If script is used from command-line as standalone

--- a/src/monitor/push-to-pushgateway.js
+++ b/src/monitor/push-to-pushgateway.js
@@ -25,6 +25,11 @@ const pushToGateway = (pushGatewayUri, metricsPayload, callback) => {
         res.setEncoding('utf8')
         res.on('data', chunk => body += chunk)
         res.on('end', () => {
+            if (res.statusCode > 204) {
+                callback(new Error(`Invalid response status code '${res.statusCode}' - response: ${body}`))
+                return
+            }
+
             callback(null, {
                 res,
                 body,


### PR DESCRIPTION
## Description

This PR add error handling when the push of metrics to the pushgateway is failing.

**Note**: I also added shell script option `set -e` to `src/compute/coverage-for-folder.sh` and `src/monitor/push-metrics-all-folders.sh` to make sure that those scripts exits with a failure error code if any command inside them is failing.

## Functional review

You can see here the workflow running in `ui-kit` repo, successfully with those updates:
- https://github.com/jobteaser/ui-kit/actions/runs/1491513175

You can see here the workflow failing in `ui-kit` repo, as expected, when an error is intentionally occurring during the process:
- https://github.com/jobteaser/ui-kit/runs/4290183528?check_suite_focus=true
- https://github.com/jobteaser/ui-kit/actions/runs/1491494439