### PR TITLE
feat(push-to-gateway): add ability to retry pushing metrics

### DIFF
--- a/config/jest.config.json
+++ b/config/jest.config.json
@@ -1,0 +1,7 @@
+{
+    "verbose": true,
+    "bail": true,
+    "rootDir": "../",
+    "roots": ["<rootDir>/src"],
+    "silent": true
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Github action for compute and monitor of test coverage via jest",
   "main": "index.js",
   "scripts": {
-    "test": "jest src/"
+    "test": "jest src/ --config ./config/jest.config.json"
   },
   "repository": {
     "type": "git",

--- a/src/monitor/constants.js
+++ b/src/monitor/constants.js
@@ -1,0 +1,4 @@
+module.exports = {
+    MAX_ATTEMPTS: 5,
+    RETRY_DELAY: 1000, // ms
+}

--- a/src/monitor/push-metrics-for-folder.spec.js
+++ b/src/monitor/push-metrics-for-folder.spec.js
@@ -1,5 +1,6 @@
 const path = require("path")
 const fs = require("fs")
+const { MAX_ATTEMPTS } = require('./constants')
 const { pushToGateway } = require('./push-to-pushgateway.js')
 const { pushMetricsForFolder } = require("./push-metrics-for-folder")
 
@@ -53,7 +54,7 @@ describe("pushMetricsForFolder", () => {
         expect(lastMockCallArgs[1]).toEqual("{\"foo\":\"bar\"}")
     })
 
-    it("should attempt 5 times to push metrics before failing", () => {
+    it(`should attempt ${MAX_ATTEMPTS} times to push metrics before failing`, () => {
         jest.useFakeTimers()
 
         let attemptsCount = 0
@@ -72,6 +73,6 @@ describe("pushMetricsForFolder", () => {
                 pushGatewayUri: "http://pushgateway",
             })
         }).toThrow(/Test error/)
-        expect(attemptsCount).toEqual(5)
+        expect(attemptsCount).toEqual(MAX_ATTEMPTS)
     })
 })


### PR DESCRIPTION
## Description

This PR adds ability to retry pushing metrics to the pushgateway if it fails (due to network error for ex).
Current retry settings are:
- Retry 5 times at max
- Wait for 3 seconds between each retry