### PR TITLE
feat(node): update action to use node@16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       image: jobteaser/node:2.0.0
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           path: workspace
       - name: "Install NPM dependencies"

--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ jobs:
     container: node:10.13-jessie
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       # If using private repositories in your package.json file
       - name: "Setup SSH key for private repos"
-        uses: webfactory/ssh-agent@v0.5.0
+        uses: webfactory/ssh-agent@v0.7.0
         with:
           ssh-private-key: ${{ secrets.GH_USER_PRIVATE_SSH_KEY }}
       # If using private NPM packages in your package.json file
@@ -204,7 +204,7 @@ jobs:
 
       # This upload step allows to share coverage metrics between our 2 jobs
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: coverage-artifacts
           path: coverage-artifacts.tar.gz
@@ -217,7 +217,7 @@ jobs:
     steps:
       # Download coverage metrics previously uploaded
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3.0.0
         with:
           name: coverage-artifacts
 


### PR DESCRIPTION
## Description

The present PR updates few actions that will be deprecated because they use node@12.

![Capture d’écran 2022-10-24 à 17 11 16](https://user-images.githubusercontent.com/100044/197561461-2101a699-d460-45e0-9382-a108a81b0695.png)

## Functional review

See these wf runs that were forced to confirm that it still works:
- ui-jobteaser: https://github.com/jobteaser/ui-jobteaser/actions/runs/3314008108
- ui-kit: https://github.com/jobteaser/ui-kit/actions/runs/3314033746